### PR TITLE
Fix failing test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.4
 
 Style/StringLiterals:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,9 @@ Layout/LineLength:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+
+Style/Documentation:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false

--- a/exe/kageuchi
+++ b/exe/kageuchi
@@ -4,5 +4,5 @@
 require "kageuchi"
 require "kageuchi/server"
 
-server = Kageuchi::Server.new(3000)
+server = Kageuchi::Server.new("127.0.0.1", 1234)
 server.start

--- a/lib/kageuchi/server.rb
+++ b/lib/kageuchi/server.rb
@@ -6,14 +6,15 @@ module Kageuchi
   class Server
     attr_reader :status, :logs
 
-    def initialize(port)
+    def initialize(host = "localhost", port = 3000)
+      @host = host
       @port = port
       @logs = []
       @status = :created
     end
 
     def start
-      @server = TCPServer.open(@port)
+      @server = TCPServer.open(@host, @port)
 
       loop do
         socket = @server.accept

--- a/lib/kageuchi/server.rb
+++ b/lib/kageuchi/server.rb
@@ -18,8 +18,8 @@ module Kageuchi
 
       loop do
         socket = @server.accept
-        match = socket.gets.chomp.match(/^(?<verb>[A-Z]*) (?<path>[^ ]*) (?<ver>.*)$/)
-        if match
+        request_params = socket.gets.chomp.match(/^(?<verb>[A-Z]*) (?<path>[^ ]*) (?<ver>.*)$/)
+        if request_params
           headers = []
           while line = socket.gets.chomp
             break if line.bytesize.zero?
@@ -27,13 +27,13 @@ module Kageuchi
             headers << line.split(": ")
           end
           request = {
-            VERB: match[:verb],
-            PATH: match[:path],
-            VERSION: match[:ver],
+            VERB: request_params[:verb],
+            PATH: request_params[:path],
+            VERSION: request_params[:ver],
             HEDERS: headers
           }
-          @logs << request
           pp request
+          @logs << request
         end
 
         @status = :running

--- a/lib/kageuchi/server.rb
+++ b/lib/kageuchi/server.rb
@@ -4,7 +4,7 @@ require "socket"
 
 module Kageuchi
   class Server
-    attr_reader :status, :logs
+    attr_reader :status, :logs, :request
 
     def initialize(host = "localhost", port = 3000)
       @host = host
@@ -17,38 +17,54 @@ module Kageuchi
       @server = TCPServer.open(@host, @port)
 
       loop do
-        socket = @server.accept
-        request_params = socket.gets.chomp.match(/^(?<verb>[A-Z]*) (?<path>[^ ]*) (?<ver>.*)$/)
-        if request_params
-          headers = []
-          while line = socket.gets.chomp
-            break if line.bytesize.zero?
-
-            headers << line.split(": ")
-          end
-          request = {
-            VERB: request_params[:verb],
-            PATH: request_params[:path],
-            VERSION: request_params[:ver],
-            HEDERS: headers
-          }
-          pp request
-          @logs << request
-        end
-
+        @socket = @server.accept
         @status = :running
-        next unless line.bytesize.zero?
 
-        socket.write "HTTP/1.1 200 OK\r\n"
-        socket.write "\r\n"
-        socket.write "Hello. This is Kageuchi server\r\n"
-        socket.close
+        next unless handle
+
+        request_close
       end
     end
 
     def close
       @server.close
       @status = :closed
+    end
+
+    private
+
+    def handle
+      request_params = @socket.gets.chomp.match(/^(?<verb>[A-Z]*) (?<path>[^ ]*) (?<ver>.*)$/)
+      if request_params
+        headers, line = set_header
+        request = {
+          VERB: request_params[:verb],
+          PATH: request_params[:path],
+          VERSION: request_params[:ver],
+          HEDERS: headers
+        }
+        pp request
+        @logs << request
+      end
+
+      line.bytesize.zero?
+    end
+
+    def set_header
+      headers = []
+      while line = @socket.gets.chomp
+        break if line.bytesize.zero?
+
+        headers << line.split(": ")
+      end
+      [headers, line]
+    end
+
+    def request_close
+      @socket.write "HTTP/1.1 200 OK\r\n"
+      @socket.write "\r\n"
+      @socket.write "Hello. This is Kageuchi server\r\n"
+      @socket.close
     end
   end
 end

--- a/spec/kageuchi/server_spec.rb
+++ b/spec/kageuchi/server_spec.rb
@@ -16,14 +16,17 @@ RSpec.describe Kageuchi::Server do
     end
   end
 
-  let(:host) { "localhost" }
-  let(:port) { 1234 }
+  let(:host) { "127.0.0.1" }
+  let(:port) { 32_768 }
   let(:server) { Kageuchi::Server.new(host, port) }
 
   before do
     Thread.new do
       server.start
     end
+
+    # Wait for the server to start
+    sleep 1
 
     RequestSender.new(host, port)
     sleep 1 while server.status != :running

--- a/spec/kageuchi/server_spec.rb
+++ b/spec/kageuchi/server_spec.rb
@@ -7,36 +7,35 @@ require "uri"
 
 RSpec.describe Kageuchi::Server do
   class RequestSender # rubocop:disable Lint/ConstantDefinitionInBlock
-    def initialize
-      uri = URI.parse("http://localhost:3000/hello")
-      req = Net::HTTP::Get.new(uri.path)
-      res = Net::HTTP.start(uri.host, uri.port) do |http|
-        http.request(req)
+    def initialize(host, port)
+      uri = URI.parse("http://#{host}:#{port}/hello")
+      request = Net::HTTP::Get.new(uri.path)
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        http.request(request)
       end
-
-      p res
     end
   end
 
-  before do
-    port = 1234
-    @server = Kageuchi::Server.new(port)
+  let(:host) { "localhost" }
+  let(:port) { 1234 }
+  let(:server) { Kageuchi::Server.new(host, port) }
 
+  before do
     Thread.new do
-      @server.start
+      server.start
     end
 
-    RequestSender.new
-    sleep 1 while @server.status != :running
+    RequestSender.new(host, port)
+    sleep 1 while server.status != :running
   end
 
   after do
-    @server.close
+    server.close
   end
 
   describe "#start" do
-    it "" do
-      expect(@server.logs.first).to eq(
+    it do
+      expect(server.logs.first).to eq(
         {
           VERB: "GET",
           PATH: "/hello",
@@ -45,7 +44,7 @@ RSpec.describe Kageuchi::Server do
             ["Accept-Encoding", "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
             ["Accept", "*/*"],
             %w[User-Agent Ruby],
-            ["Host", "localhost:3000"]
+            ["Host", "#{host}:#{port}"]
           ]
         }
       )


### PR DESCRIPTION
## Error message in GitHub Actions

I don't know why, but locally, it's successful.

```
Run gem install bundler -v 2.2.15
Successfully installed bundler-2.2.15
1 gem installed
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Fetching rake 13.0.3
Installing rake 13.0.3
Using bundler 2.2.15
Fetching ast 2.4.2
Fetching diff-lcs 1.4.4
Installing ast 2.4.2
Installing diff-lcs 1.4.4
Using kageuchi 0.1.0 from source at `.` and installing its executables
Fetching parallel 1.20.1
Installing parallel 1.20.1
Fetching rainbow 3.0.0
Fetching regexp_parser 2.1.1
Installing rainbow 3.0.0
Installing regexp_parser 2.1.1
Fetching rexml 3.2.4
Installing rexml 3.2.4
Fetching rspec-support 3.10.2
Fetching ruby-progressbar 1.11.0
Installing rspec-support 3.10.2
Installing ruby-progressbar 1.11.0
Fetching unicode-display_width 2.0.0
Fetching parser 3.0.0.0
Installing unicode-display_width 2.0.0
Fetching rspec-core 3.10.1
Installing parser 3.0.0.0
Installing rspec-core 3.10.1
Fetching rspec-expectations 3.10.1
Fetching rspec-mocks 3.10.2
Installing rspec-expectations 3.10.1
Installing rspec-mocks 3.10.2
Fetching rubocop-ast 1.4.1
Fetching rspec 3.10.0
Installing rubocop-ast 1.4.1
Installing rspec 3.10.0
Fetching rubocop 1.12.1
Installing rubocop 1.12.1
Bundle complete! 4 Gemfile dependencies, 19 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
/opt/hostedtoolcache/Ruby/2.7.2/x64/bin/ruby -I/opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/gems/2.7.0/gems/rspec-core-3.10.1/lib:/opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/gems/2.7.0/gems/rspec-support-3.10.2/lib /opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/gems/2.7.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Kageuchi::Server
  #start
#<Thread:0x0000557b7fd80fb8 /home/runner/work/kageuchi/kageuchi/spec/kageuchi/server_spec.rb:25 run> terminated with exception (report_on_exception is true):
/home/runner/work/kageuchi/kageuchi/lib/kageuchi/server.rb:19:in `accept': stream closed in another thread (IOError)
    example at ./spec/kageuchi/server_spec.rb:38 (FAILED - 1)
	from /home/runner/work/kageuchi/kageuchi/lib/kageuchi/server.rb:19:in `block in start'

	from /home/runner/work/kageuchi/kageuchi/lib/kageuchi/server.rb:18:in `loop'
Kageuchi
	from /home/runner/work/kageuchi/kageuchi/lib/kageuchi/server.rb:18:in `start'
  has a version number
	from /home/runner/work/kageuchi/kageuchi/spec/kageuchi/server_spec.rb:26:in `block (3 levels) in <top (required)>'

Failures:

  1) Kageuchi::Server#start 
     Failure/Error:
       res = Net::HTTP.start(uri.host, uri.port) do |http|
         http.request(req)
       end

     Errno::ECONNREFUSED:
       Failed to open TCP connection to localhost:1234 (Connection refused - connect(2) for "localhost" port 1234)
     # ./spec/kageuchi/server_spec.rb:13:in `initialize'
     # ./spec/kageuchi/server_spec.rb:29:in `new'
     # ./spec/kageuchi/server_spec.rb:29:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Errno::ECONNREFUSED:
     #   Connection refused - connect(2) for "localhost" port 1234
     #   ./spec/kageuchi/server_spec.rb:13:in `initialize'

Finished in 0.00436 seconds (files took 0.1377 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/kageuchi/server_spec.rb:38 # Kageuchi::Server#start 

/opt/hostedtoolcache/Ruby/2.7.2/x64/bin/ruby -I/opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/gems/2.7.0/gems/rspec-core-3.10.1/lib:/opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/gems/2.7.0/gems/rspec-support-3.10.2/lib /opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/gems/2.7.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
Error: Process completed with exit code 1.
```
